### PR TITLE
Fix bug in scripts/create-ft-market which caller is not the owner of Contract Id

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -144,7 +144,7 @@ init-dex:
     near call $TONIC_CONTRACT_ID storage_deposit --deposit 0.1 --accountId $NEAR_ACCOUNT_ID
 
     info Creating default market with dev tokens
-    scripts/create-ft-market $NEAR_ACCOUNT_ID $TONIC_CONTRACT_ID \
+    scripts/create-ft-market $TONIC_CONTRACT_ID \
         $base_token_id \
         $base_token_lot_size \
         $quote_token_id \

--- a/scripts/create-ft-market
+++ b/scripts/create-ft-market
@@ -1,10 +1,10 @@
 #!/bin/bash
 caller=$1
-dex_contract=$2
-base_token=$3
-base_token_lot_size=$4
-quote_token=$5
-quote_token_lot_size=$6
+dex_contract=$1
+base_token=$2
+base_token_lot_size=$3
+quote_token=$4
+quote_token_lot_size=$5
 
 
 near call $dex_contract create_market \


### PR DESCRIPTION
When run current Justfile, it have an issue below:
'Smart contract panicked: Method can only be called by contract owner ID'